### PR TITLE
Maintenance

### DIFF
--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1606,11 +1606,19 @@
                                             (str t) (str k) (str v)))
                               old)))
                         (fn [old-meta]
-                          (if-not (and o p)
-                            old-meta
-                            (update-in old-meta [:ktable/topic-partition-offsets t p]
+                          (cond-> old-meta
+                            (and o p)
+                            (update-in [:ktable/topic-partition-offsets t p]
                                        (fnil #(max % o)
-                                             -1)))))
+                                             -1))
+
+                            hdrs
+                            (assoc-in [:ktable/record-headers t k]
+                                      hdrs)
+
+                            (not hdrs)
+                            (update-in [:ktable/record-headers t]
+                                       #(dissoc % k)))))
              rest-msgs))))
 
 (s/def ::ktable-id (s/and string?

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -247,9 +247,11 @@
              confluent-api-key confluent-api-secret ;; confluent
              extra-strategies
              topic-predicate
-             preserve-internal-and-confluent-topics]
+             preserve-internal-and-confluent-topics
+             dry-run?]
       :or {extra-strategies                       []
-           preserve-internal-and-confluent-topics true}}]
+           preserve-internal-and-confluent-topics true
+           dry-run?                               false}}]
   (when-not preserve-internal-and-confluent-topics
     (log/warn "Old option `preserve-internal-and-confluent-topics` used. This option is ignored. No internal topics will be deleted."))
 
@@ -274,8 +276,9 @@
     (when (seq topics-to-be-deleted)
       (log/infof "Deleting these topics:\n%s"
                  (str topics-to-be-deleted))
-      (.all (.deleteTopics ^org.apache.kafka.clients.admin.AdminClient @admin-client
-                           topics-to-be-deleted)))
+      (when-not dry-run?
+        (.all (.deleteTopics ^org.apache.kafka.clients.admin.AdminClient @admin-client
+                             topics-to-be-deleted))))
 
     ;; to release the resources of the admin-client
     (-comp/halt admin-client)))


### PR DESCRIPTION
- fix issue with `CaughtUpOnceNotificationStrategy`, used on some ktables. Sometimes the ktable's `deref/@` returns before initial data has finished loading
- add `dryrun` flag to _delete topics_ utility
- store ktable records' headers in meta-data on ktable value and not only on the values themselves.