### PR TITLE
Maintenance

### DIFF
--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -836,7 +836,9 @@
   [consumer timeout timeout-value]
   (let [current-offsets (consumer-current-offsets consumer :timeout-value :throw)
         end-offsets (consumer-end-offsets consumer :timeout-value :throw)]
-    (when (= end-offsets current-offsets)
+    (when (and current-offsets
+               end-offsets
+               (= end-offsets current-offsets))
       end-offsets)))
 
 (defstrategy CaughtUpNotifications

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -2030,13 +2030,13 @@
              ;; We need the path [topic record-key] to the records we will expunge
              ;; so we can expunge table-level meta-data too
              topic-partition-keys (map (juxt first second)
-                                       (specter/select [specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect topic name, continue to topic value-map
+                                       (specter/select [:ktable/record-data
+                                                        specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect topic name, continue to topic value-map
                                                         specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect record key, continue to record value
-                                                        specter/META                                                 ;; navigate into the record's meta-data
                                                         :timestamp                                                   ;; navigate to :timestamp
                                                         #(t/before? % cutoff-timestamp)                              ;; match only when :timestamp is before cutoff
                                                         ]
-                                                       result))
+                                                       (meta result)))
              result-without-records (reduce (fn [acc [topic record-key]]
                                               (update acc topic dissoc record-key))
                                             result

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -861,7 +861,7 @@
           [_ consumer _consumed-records]
         ;; Test if we've caught up to the last offset for every topic-partition we're consuming from
         (let [current-offsets? (consumer:fully-current? consumer (t/duration 10 :seconds) :timeout)]
-          (when (and current-offsets ?
+          (when (and current-offsets?
                      (not= current-offsets? :timeout))
             (csp/>!! caught-up-ch
                      current-offsets?)))))))

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -861,7 +861,8 @@
           [_ consumer _consumed-records]
         ;; Test if we've caught up to the last offset for every topic-partition we're consuming from
         (let [current-offsets? (consumer:fully-current? consumer (t/duration 10 :seconds) :timeout)]
-          (when (not= current-offsets? :timeout)
+          (when (and current-offsets ?
+                     (not= current-offsets? :timeout))
             (csp/>!! caught-up-ch
                      current-offsets?)))))))
 

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1803,9 +1803,12 @@
 
 (defprotocol IKTable
   (ktable-wait-for-catchup
-    [_this topic-partition-offset timeout-period timeout-value]
+    [_this topic-partition-offset timeout-duration timeout-value]
     "Waits until a ktable has consumed messages from its source topics, at least up to the topic-partition-offset data parameter.
-Supports a timeout operation."))
+Supports a timeout operation. `timeout-duration` must be a java.time.Duration.")
+  (ktable-wait-until-fully-current
+    [_this timeout-period timeout-value]
+    "Waits until the current offset is also the latest offset. This might time out if there are still active producers to the ktable, and the consumer struggle to fully catch up as a result."))
 
 (s/def ::ktable #(satisfies? IKTable %))
 
@@ -1889,7 +1892,24 @@ Supports a timeout operation."))
                   (deliver has-caught-up-once true)
                   (csp/close! caught-up-ch))
 
-        topic-partition-offset-ch (csp/chan)
+        ;; topic-partition-offset-ch (csp/chan) ;; why was this here?
+
+        ;; `caught-up-once?` mechanism is a way to block the initial ktable (deref) call until the ktable consumer
+        ;; was current at least once, relative to when the consumer started.
+        ;; latest-offsets are checked initially, and when the consumer's current-offset surpasses this, the
+        ;; check is passed. It is special because it does not check if the consumer is fully
+        ;; current all the time, but instead checks if the consumer caught up to where the offsets were
+        ;; at the time of starting. It is a type of "caught up enough to be useful" check.
+
+        ;; If `caught-up-once?` is false, then the first deref will only return if the consumer's
+        ;; current-offset is the same as latest-offset, which could be tricky of a producer is busy producing
+        ;; records to this topic while the first deref is waiting.
+
+        fully-current-notification-ch (csp/chan (csp/sliding-buffer 1))
+        caught-up-notifications-strategy (apply CaughtUpNotifications
+                                                (remove nil? [fully-current-notification-ch
+                                                              (when-not caught-up-once?
+                                                                caught-up-ch)]))
 
         ktable-state (atom {})
         consumer-client (reify
@@ -1901,12 +1921,11 @@ Supports a timeout operation."))
                                      #(merge-updates-with-ktable % msgs)))))
 
         cfg (-> cfg
-                (update-in [:strategies] concat [(OffsetReset "earliest")
-                                                 (ConsumerGroup consumer-group-id)
-                                                 (if caught-up-once?
-                                                   (CaughtUpOnceNotifications caught-up-ch)
-                                                   (CaughtUpNotifications caught-up-ch))
-                                                 ])
+                (update-in [:strategies] concat (remove nil?
+                                                        [(OffsetReset "earliest")
+                                                         (ConsumerGroup consumer-group-id)
+                                                         (when caught-up-once? (CaughtUpOnceNotifications caught-up-ch))
+                                                         caught-up-notifications-strategy]))
                 (assoc :consumer/client consumer-client))
 
         consumer (make-consumer cfg)]
@@ -1916,8 +1935,35 @@ Supports a timeout operation."))
       (halt [_] (-comp/halt consumer))
 
       IKTable
-      (ktable-wait-for-catchup [_ topic-partition-offset timeout-period timeout-value]
-        (ktable-atom-wait-for-catchup ktable-state topic-partition-offset timeout-period timeout-value))
+      (ktable-wait-for-catchup [_ topic-partition-offset timeout-duration timeout-value]
+        (ktable-atom-wait-for-catchup ktable-state topic-partition-offset timeout-duration timeout-value))
+      (ktable-wait-until-fully-current [_ timeout-duration timeout-value]
+        (let [timeout-ms (.toMillis ^java.time.Duration timeout-duration)
+              timeout-chan (csp/timeout timeout-ms)]
+          ;; When a ktable is current these `fully-current-notification-ch` will fire often.
+          ;; We will count until we've received two notification channels before returning from this fn.
+          ;; This is done because `fully-current-notification-ch` will likely contain
+          ;; values of having been current before this call, so we need at least one receive
+          ;; to clear it.
+          (loop [current-notifs-received 0
+                 previous-offsets        nil]
+            (let [[v ch] (csp/alts!! [timeout-chan
+                                      fully-current-notification-ch])]
+              (if (= ch timeout-chan)
+                timeout-value
+
+                ;; if we've received a value, we want to receive the _same_ value
+                ;; from the `fully-current-notification-ch` at least twice
+                ;; to indicate stability, ie fully caught to a stable point.
+                (let [same-as-previous?            (= v previous-offsets)
+                      next-current-notifs-received (if same-as-previous?
+                                                     (inc current-notifs-received)
+                                                     0)]
+                  ;; if we've received the same offsets twice, we're good to return
+                  (if (= 2 next-current-notifs-received)
+                    v
+                    ;; else we wait some more
+                    (recur next-current-notifs-received v))))))))
 
       IDeref
       (deref [_]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -325,7 +325,25 @@
        (apply ~n (rest strategy-specs#)))))
 
 
-;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defstrategy RenameTopicsForProducer
+  [& {:keys [rename-fn]}]
+  (when-not rename-fn
+    (throw (ex-info (str "strategy RenameTopicsForProducer requires the `rename-fn` to be specified. This function "
+                         "accepts a topic name for every message, and must return a modified version of the topic, "
+                         "OR nil, in which case the original topic value will be kept.")
+                    {})))
+  (reify
+    IProducerPreProduceMiddleware
+    (pre-produce-hook [_ msgs]
+      (map (fn [{:as   msg
+                 :keys [topic]}]
+             (assoc msg :topic (or (rename-fn topic)
+                                   topic)))
+           msgs))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- get-allowed-config-keys
     [config-class]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1912,8 +1912,6 @@ Supports a timeout operation. `timeout-duration` must be a java.time.Duration.")
                   (deliver has-caught-up-once true)
                   (csp/close! caught-up-ch))
 
-        ;; topic-partition-offset-ch (csp/chan) ;; why was this here?
-
         ;; `caught-up-once?` mechanism is a way to block the initial ktable (deref) call until the ktable consumer
         ;; was current at least once, relative to when the consumer started.
         ;; latest-offsets are checked initially, and when the consumer's current-offset surpasses this, the

--- a/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
+++ b/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
@@ -12,8 +12,9 @@
 
 (s/def :topic-forwarder-cfg/msg-filter fn?)
 (s/def :topic-forwarder-cfg/msg-transform fn?)
-(s/def :topic-forwarder-cfg/topics (s/or :string-col     ::-kafka/topics
-                                         :topic-provider ::-kafka/topic-name-provider))
+(s/def :topic-forwarder-cfg/topics (s/or :string-col         ::-kafka/topics
+                                         :topic-provider     ::-kafka/topic-name-provider
+                                         :topic-provider-col (s/coll-of ::-kafka/topic-name-provider)))
 
 (s/def :topic-forwarder-cfg/src (s/and ::topic-forwarder-cluster-cfg
                                        (s/keys :req-un [:topic-forwarder-cfg/topics]
@@ -102,9 +103,11 @@
     :as                          config}]
   (assoc-in config [:src-cluster-cfg :topics]
             (case option-kw
-              :string-col     [:strategy/SubscribeWithTopicsCollection topics]
-              :topic-provider [:strategy/SubscribeWithTopicNameProvider
-                               :topic-name-providers [topics]])))
+              :string-col         [:strategy/SubscribeWithTopicsCollection topics]
+              :topic-provider     [:strategy/SubscribeWithTopicNameProvider
+                                   :topic-name-providers [topics]]
+              :topic-provider-col [:strategy/SubscribeWithTopicNameProvider
+                                   :topic-name-providers topics])))
 
 (defn create-system-config
   [& cfg]

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -107,17 +107,17 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn read-instance-id-values
-  "Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work."
-  []
-  (let [{:keys [status error body]}
-        @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
-    (if (or error (not= 200 status))
-      nil
-      (json/read-str body))))
+;; Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work.
+(def instance-id-values
+  (delay
+    (let [{:keys [status error body]}
+          @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
+      (if (or error (not= 200 status))
+        nil
+        (json/read-str body)))))
 
-(defmethod aero/reader 'ec2-instance-identity-value
-  [_ _ value] (get (read-instance-id-values) value))
+(defmethod aero/reader 'ec2/instance-identity-data
+  [_ _ value] (get @instance-id-values value))
 
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -1,11 +1,15 @@
 (ns afrolabs.config
-  (:require [aero.core :as aero]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [integrant.core :as ig]
-            [taoensso.timbre :as log]
-            [clojure.data.csv :as csv]
-            [clojure.edn :as edn]))
+  (:require
+   [aero.core :as aero]
+   [clojure.data.csv :as csv]
+   [clojure.edn :as edn]
+   [clojure.data.json :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [integrant.core :as ig]
+   [org.httpkit.client :as http]
+   [taoensso.timbre :as log]
+   ))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -100,6 +104,20 @@
 (defmethod aero/reader 'ip-hostname
   [_ _ _value]
   (.getHostName (java.net.InetAddress/getLocalHost)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn read-instance-id-values
+  "Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work."
+  []
+  (let [{:keys [status error body]}
+        @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
+    (if (or error (not= 200 status))
+      nil
+      (json/read-str body))))
+
+(defmethod aero/reader 'ec2-instance-identity-value
+  [_ _ value] (get (read-instance-id-values) value))
 
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))


### PR DESCRIPTION
## Improvements to ktables

- support optional config `:retention-ms`, which will expunge data from ktables if their respective value-records' `:timestamp` field is older than some numbef of milliseconds
- will limit the amount of data loaded from the ktable by seeking to an appropriate partition timestamp-offset
- re-arrange the meta-data on ktables, soft-deprecate `:ktable/record-headers` in favour of `:ktable/record-data`.
